### PR TITLE
fix zed_wrapper building error

### DIFF
--- a/zed_wrapper/CMakeLists.txt
+++ b/zed_wrapper/CMakeLists.txt
@@ -4,6 +4,9 @@ project(zed_wrapper)
 ## Generate symbols for IDE indexer
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Add compiler flags. This is related to this issue: https://github.com/stereolabs/zed-sdk/issues/212
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--allow-shlib-undefined")
+
 ################################################
 # Check the ROS2 version
 


### PR DESCRIPTION
This PR is related to the issue of not being able to build zed_wrapper in the new docker file 